### PR TITLE
Update community.json

### DIFF
--- a/public/community.json
+++ b/public/community.json
@@ -515,4 +515,11 @@
         "link": "https://github.com/uxsoft/Fable.MomentJs",
         "category": "library"
     }
+    {
+        "title": "Fable SignalR Client Demo",
+        "description": "Demo for connecting to SignalR via Fable/Elmish through JS Interop",
+        "link": "https://github.com/steelcityrkp/fable-signalr-minimal",
+        "category": "sample"
+    }
+    
 ]


### PR DESCRIPTION
This demo enables a Fable app that can be used instead of the Vue.js app that is in Microsoft Serverless SignalR Demo.  This may be helpful to people getting started and trying to see how they could plug into SignalR.  This is just meant to be a minimal starting point and keeps the same conventions as the Vue.js app for intercompatibility.